### PR TITLE
[EDIFICE]: #Wb2-1467, Améliorations des perf et de la stabilité

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -1,4 +1,5 @@
 {
+    "processTimeoutAsMin": "10",
     "auth": "ZXhwb3J0cGRmOnNlY3JldA==",
     "bypassWhitelist": true,
     "domainWhitelist": [

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+const cluster = require('cluster');
+const os = require('os');
+
+if (cluster.isMaster) {
+    // create 1 process per cpu
+    os.cpus().forEach(() => {
+        cluster.fork();
+    });
+    // restart if process has been killed
+    cluster.on('exit', (worker) => {
+        console.log(`Process hash been killed ${worker.process.pid} restarting...`);
+        cluster.fork();
+    });
+} else {
+    // call main code
+    require("./app")
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-pdf-generator",
   "version": "1.1.9",
   "scripts": {
-    "start": "npm install && node app.js"
+    "start": "npm install && node index.js"
   },
   "dependencies": {
     "express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-pdf-generator",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "scripts": {
     "start": "npm install && node index.js"
   },


### PR DESCRIPTION
De manière aléatoire le service pdf de prod sature (CPU 100% pendant des heures / jours) et le service pdf se dégrade.
Sur certaines applications le service imprime des pages vides (alors que les mêmes ressource sur un autre environnement local, recette ou preprod fonctionne correctement)
Le but de ce fix est d'imposer une durée limite au process enfant de conversion de pdf et aussi d'exploiter tout les core de la machine de production.